### PR TITLE
Fix text contrast and improve visibility on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,16 +129,12 @@
         }
 
         .hero h2 {
-            font-family: 'Playfair Display', serif;
-            font-size: clamp(2.4rem, 6vw, 3.8rem); /* Smaller hero */
-            font-weight: 700;
-            background: linear-gradient(135deg, #FFFFFF 0%, rgba(255,255,255,0.9) 100%);
-            -webkit-background-clip: text;
-            background-clip: text;
-            -webkit-text-fill-color: transparent;
-            margin-bottom: 1.5rem;
-            line-height: 1.15;
-            text-shadow: 0 6px 24px rgba(0,0,0,0.25);
+           font-family: 'Playfair Display', serif;
+    font-size: clamp(2.6rem, 5vw, 3.4rem);
+    font-weight: 700;
+    color: var(--charcoal-dark); /* dark grey for contrast */
+    margin-bottom: 1.5rem;
+    text-shadow: 0 2px 8px rgba(255, 255, 255, 0.6);
         }
 
         .hero p {
@@ -313,6 +309,14 @@
         .programs .card p {
             color: rgba(255,255,255,0.9);
         }
+        .programs h3 {
+    color: var(--primary-white);
+}
+
+.programs p {
+   color: #f1f1f1;
+}
+
 
         /* Newsletter - Smaller */
         .newsletter {


### PR DESCRIPTION
This PR fixes the text visibility and contrast issues on the home page:

- Hero section heading now clearly visible against background
- Legendary Open Source Program section text improved for readability
- Golden & grey theme consistency maintained
- Minor CSS adjustments for better UI/UX

Screenshots
-Hero Section:
<img width="1920" height="1200" alt="Screenshot (44)" src="https://github.com/user-attachments/assets/d70950c8-642c-4c24-968d-7671b8f6a213" />

 -Programs Section:
<img width="1920" height="1200" alt="Screenshot (45)" src="https://github.com/user-attachments/assets/fb6f83b7-469b-403a-a1ca-2f24fbe835b7" />

