### PR TITLE
Add contributors section with avatars and GitHub star and fork stats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,27 @@ OpenSource-Compass/
 
 ---
 
+<div align="left">
+
+## 🌍 Community & Contributors
+
+### 💖 Contributors  
+Thanks to these amazing people who have contributed to **OpenSource Compass** ✨  
+
+<a href="https://github.com/sayeeg-11/OpenSource-Compass/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=sayeeg-11/OpenSource-Compass" alt="Contributors" />
+</a>
+
+<br/><br/>
+
+### ⭐ Project Support
+
+[![Stars](https://img.shields.io/github/stars/sayeeg-11/OpenSource-Compass?style=social)](https://github.com/sayeeg-11/OpenSource-Compass/stargazers)
+&nbsp;&nbsp;
+[![Forks](https://img.shields.io/github/forks/sayeeg-11/OpenSource-Compass?style=social)](https://github.com/sayeeg-11/OpenSource-Compass/network/members)
+
+</div>
+
 ## 🤝 Contribution Guidelines (SWOC’26)
 
 ### How to Contribute


### PR DESCRIPTION
This PR adds a contributors section to the README showing avatars and username , along with live fork and star stats.

<img width="1122" height="416" alt="Screenshot 2026-01-11 at 11 49 50 PM" src="https://github.com/user-attachments/assets/1dfe0e8a-d882-4aa2-bcb6-9402ff916a1f" />
<img width="1238" height="502" alt="Screenshot 2026-01-11 at 11 50 30 PM" src="https://github.com/user-attachments/assets/810822ec-3ac3-48b3-9565-4bf3b6d05fff" />
 

Fixes #43 