### PR TITLE
fix: update broken banner image path in README #250

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # 🌍 OpenSource Compass  
 ### Navigate Your Open Source Journey with Confidence
 
-<img src="assets/updated image.png" alt="OpenSource Compass – SWOC'26 Banner" width="100%" />
+<img src="frontend/library/assets/swoc_banner.png" alt="OpenSource Compass – SWOC'26 Banner" width="100%" />
 
 [![Open Source](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/sayeeg-11/OpenSource-Compass)
 [![GitHub Issues](https://img.shields.io/github/issues/sayeeg-11/OpenSource-Compass)](https://github.com/sayeeg-11/OpenSource-Compass/issues)


### PR DESCRIPTION
### Description
Fixed the broken image link for the SWOC banner in the `README.md` file. The previous path `assets/updated image.png` was incorrect. I have updated the `src` attribute to point to the correct file location: `frontend/library/assets/swoc_banner.png`.

### Related Issue
Closes #250 

### Changes Made
- Updated `README.md`: Changed image source path to `frontend/library/assets/swoc_banner.png`.

### Screenshots
<img width="874" height="808" alt="image" src="https://github.com/user-attachments/assets/33328ad6-6896-4fc7-9ef4-6f6246108e64" />
