### PR TITLE
Design a page to aggregate all guide pdfs

### DIFF
--- a/frontend/css/pdf_guide.css
+++ b/frontend/css/pdf_guide.css
@@ -1,0 +1,427 @@
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html,
+body {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+/* CSS Variables */
+:root {
+  --primary-gold: #d4af37;
+  --secondary-gold: #b8860b;
+  --deep-navy: #1b263b;
+  --warm-cream: #fdf4e3;
+  --light-parchment: #fff8e7;
+  --charcoal-dark: #2c2c2c;
+  --text-secondary: #5a5a5a;
+  --shadow-main: 0 8px 32px rgba(0, 0, 0, 0.12);
+  --shadow-hover: 0 20px 40px rgba(0, 0, 0, 0.18);
+}
+
+/* Body Styling */
+body {
+  font-family: "Crimson Text", Georgia, serif;
+  font-size: 15px;
+  line-height: 1.7;
+  background: linear-gradient(
+    135deg,
+    var(--light-parchment) 0%,
+    var(--warm-cream) 100%
+  );
+  color: var(--charcoal-dark);
+}
+
+/* HEADER / NAVBAR */
+
+header {
+  background: rgba(255, 255, 255, 0.98);
+  backdrop-filter: saturate(180%) blur(20px);
+  border-bottom: 3px solid var(--primary-gold);
+  padding: 1rem 6%;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  box-shadow: var(--shadow-main);
+}
+
+.navbar-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+header h1 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.6rem, 3vw, 1.9rem);
+  font-weight: 700;
+  background: linear-gradient(
+    135deg,
+    var(--deep-navy) 0%,
+    var(--primary-gold) 70%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.01em;
+}
+
+header h1 i {
+  font-size: 0.95em;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: var(--charcoal-dark);
+  font-family: "Inter", -apple-system, sans-serif;
+  font-weight: 500;
+  font-size: 0.95rem;
+  padding: 0.4rem 0;
+  position: relative;
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.nav-links a::before {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 0;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    var(--primary-gold),
+    var(--secondary-gold)
+  );
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  transform: translateX(-50%);
+  border-radius: 1px;
+}
+
+.nav-links a:hover {
+  color: var(--deep-navy);
+  transform: translateY(-1px);
+}
+
+.nav-links a:hover::before {
+  width: 70%;
+}
+
+/* HERO SECTION */
+
+.hero-section {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 5rem 6% 3rem;
+  text-align: center;
+  animation: fadeInUp 0.8s ease-out;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.hero-section h2 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  font-weight: 700;
+  color: var(--deep-navy);
+  margin-bottom: 1.2rem;
+  line-height: 1.2;
+}
+
+.hero-section h2::after {
+  content: "";
+  display: block;
+  width: 120px;
+  height: 4px;
+  margin: 1.5rem auto 0;
+  background: linear-gradient(
+    90deg,
+    var(--primary-gold),
+    var(--secondary-gold)
+  );
+  border-radius: 2px;
+}
+
+.hero-section p {
+  max-width: 900px;
+  margin: 2rem auto 0;
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  line-height: 1.8;
+}
+
+/* PROGRAMS SECTION */
+
+.programs-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 3rem 6% 5rem;
+}
+
+.programs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 2.5rem;
+  margin-top: 2rem;
+}
+
+/* Program Card */
+.program-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 20px;
+  padding: 2.5rem;
+  box-shadow: var(--shadow-main);
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  border: 2px solid transparent;
+  animation: fadeInUp 0.6s ease-out backwards;
+}
+
+.program-card:nth-child(1) {
+  animation-delay: 0.1s;
+}
+.program-card:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.program-card:nth-child(3) {
+  animation-delay: 0.3s;
+}
+.program-card:nth-child(4) {
+  animation-delay: 0.4s;
+}
+.program-card:nth-child(5) {
+  animation-delay: 0.5s;
+}
+.program-card:nth-child(6) {
+  animation-delay: 0.6s;
+}
+
+.program-card:hover {
+  transform: translateY(-8px);
+  box-shadow: var(--shadow-hover);
+  border-color: var(--primary-gold);
+}
+
+/* Program Header */
+.program-header {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.program-icon {
+  font-size: 3rem;
+  background: linear-gradient(
+    135deg,
+    var(--primary-gold),
+    var(--secondary-gold)
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  flex-shrink: 0;
+  transition: transform 0.3s ease;
+}
+
+.program-card:hover .program-icon {
+  transform: scale(1.1) rotate(5deg);
+}
+
+.program-card h3 {
+  font-family: "Playfair Display", serif;
+  font-size: 1.8rem;
+  color: var(--deep-navy);
+  font-weight: 700;
+  margin-bottom: 0.3rem;
+}
+
+.program-subtitle {
+  color: var(--primary-gold);
+  font-weight: 600;
+  font-size: 0.9rem;
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.program-card p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: 1.5rem;
+}
+
+/* Program Highlights */
+.program-highlights {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 1.5rem;
+}
+
+.program-highlights li {
+  padding: 0.5rem 0;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-size: 0.95rem;
+}
+
+.program-highlights i {
+  color: var(--primary-gold);
+  font-size: 1rem;
+  width: 20px;
+}
+
+.btn-container {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.btn {
+  flex: 1;
+  padding: 0.9rem 1.5rem;
+  border-radius: 12px;
+  text-decoration: none;
+  font-weight: 600;
+  font-family: "Inter", sans-serif;
+  font-size: 0.95rem;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: 2px solid transparent;
+}
+
+.btn-primary {
+  background: linear-gradient(
+    135deg,
+    var(--primary-gold),
+    var(--secondary-gold)
+  );
+  color: white;
+  box-shadow: 0 4px 12px rgba(212, 175, 55, 0.3);
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(212, 175, 55, 0.4);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--primary-gold);
+  border-color: var(--primary-gold);
+}
+
+.btn-secondary:hover {
+  background: var(--primary-gold);
+  color: white;
+  transform: translateY(-2px);
+}
+
+
+footer {
+  background: var(--deep-navy);
+  color: var(--warm-cream);
+  text-align: center;
+  padding: 3rem 6% 2.5rem;
+  font-size: 0.95rem;
+}
+
+footer a {
+  color: var(--primary-gold);
+  text-decoration: none;
+  font-weight: 500;
+  transition: all 0.3s ease;
+}
+
+footer a:hover {
+  color: var(--secondary-gold);
+  text-decoration: underline;
+}
+
+
+@media (max-width: 768px) {
+  .navbar-container {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.8rem;
+  }
+
+  .programs-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .program-header {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .btn-container {
+    flex-direction: column;
+  }
+
+  .hero-section {
+    padding: 3rem 5% 2rem;
+  }
+
+  .programs-container {
+    padding: 2rem 5% 3rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    font-size: 14px;
+  }
+
+  .nav-links a {
+    font-size: 0.85rem;
+  }
+
+  .program-card {
+    padding: 2rem 1.5rem;
+  }
+
+  .program-icon {
+    font-size: 2.5rem;
+  }
+
+  .program-card h3 {
+    font-size: 1.5rem;
+  }
+}

--- a/frontend/pages/pdf_guide.html
+++ b/frontend/pages/pdf_guide.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Open Source Programs Guide - OpenSource Compass</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Crimson+Text:wght@400;600&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  
+  <!-- Link to external CSS file -->
+  <link rel="stylesheet" href="../css/pdf_guide.css" />
+</head>
+
+<body>
+  <!-- Navbar -->
+  <header>
+    <div class="navbar-container">
+      <h1>
+        <i class="fas fa-compass" style="color: var(--primary-gold); margin-right: 0.4rem"></i>
+        OpenSource Compass
+      </h1>
+      <div class="nav-links">
+        <a href="/OpenSource-Compass/index.html">Home</a>
+        <a href="./programs.html">Programs</a>
+        <a href="./Resources.html">Resources</a>
+        <a href="./Contribute.html">Contribute</a>
+      </div>
+    </div>
+  </header>
+
+  <!-- Hero Section -->
+  <div class="hero-section" id="home">
+    <h2>Your Complete Guide to Open Source Programs</h2>
+    <p>Discover the world's most prestigious open source internship programs. From Google Summer of Code to Outreachy, explore opportunities to contribute to real-world projects, earn stipends, and launch your tech career. Click on any program below to view the complete guide.</p>
+  </div>
+
+  <!-- Programs Grid -->
+  <div class="programs-container" id="programs">
+    
+    <!-- GSoC Card -->
+    <div class="programs-grid">
+      <div class="program-card">
+        <div class="program-header">
+          <div class="program-icon"><i class="fab fa-google"></i></div>
+          <div>
+            <h3>Google Summer of Code</h3>
+            <span class="program-subtitle">The Most Prestigious Program</span>
+          </div>
+        </div>
+        <p>A 12+ week paid program where you contribute to open-source organizations with mentorship from experienced developers. Learn about the four-phase journey and prepare for GSoC 2026.</p>
+        <ul class="program-highlights">
+          <li><i class="fas fa-clock"></i> 12-22 weeks duration</li>
+          <li><i class="fas fa-dollar-sign"></i> $1,500-$6,000 stipend</li>
+          <li><i class="fas fa-calendar"></i> Applications: Feb-March</li>
+          <li><i class="fas fa-code"></i> Technical proposal required</li>
+        </ul>
+        <div class="btn-container">
+          <a href="../library/guides_pdf/GSOC .pdf" class="btn btn-primary" target="_blank">
+            <i class="fas fa-file-pdf"></i> View Guide
+          </a>
+        </div>
+      </div>
+
+      <!-- GSSoC Card -->
+      <div class="program-card">
+        <div class="program-header">
+          <div class="program-icon"><i class="fas fa-users"></i></div>
+          <div>
+            <h3>GirlScript Summer of Code</h3>
+            <span class="program-subtitle">Beginner-Friendly & Gamified</span>
+          </div>
+        </div>
+        <p>A 3-month program with 100+ projects, a points-based leaderboard system, and rewards for top contributors. Perfect for beginners learning Git and GitHub.</p>
+        <ul class="program-highlights">
+          <li><i class="fas fa-clock"></i> 3 months duration</li>
+          <li><i class="fas fa-trophy"></i> Certificates & swag rewards</li>
+          <li><i class="fas fa-universal-access"></i> All genders welcome</li>
+          <li><i class="fas fa-gamepad"></i> Gamified point system</li>
+        </ul>
+        <div class="btn-container">
+          <a href="../library/guides_pdf/GSSOC.pdf" class="btn btn-primary" target="_blank">
+            <i class="fas fa-file-pdf"></i> View Guide
+          </a>
+        </div>
+      </div>
+
+      <!-- Hacktoberfest Card -->
+      <div class="program-card">
+        <div class="program-header">
+          <div class="program-icon"><i class="fab fa-github"></i></div>
+          <div>
+            <h3>Hacktoberfest</h3>
+            <span class="program-subtitle">Month-Long Celebration</span>
+          </div>
+        </div>
+        <p>An annual October event encouraging developers worldwide to contribute to open source projects on GitHub and GitLab. Complete 4-6 PRs to earn rewards.</p>
+        <ul class="program-highlights">
+          <li><i class="fas fa-clock"></i> 1 month (Every October)</li>
+          <li><i class="fas fa-gift"></i> Digital badges & swag</li>
+          <li><i class="fas fa-code"></i> 4-6 PRs to complete</li>
+          <li><i class="fas fa-globe"></i> Hosted by DigitalOcean</li>
+        </ul>
+        <div class="btn-container">
+          <a href="../library/guides_pdf/Hacktoberfest.pdf" class="btn btn-primary" target="_blank">
+            <i class="fas fa-file-pdf"></i> View Guide
+          </a>
+        </div>
+      </div>
+
+      <!-- LFX Mentorship Card -->
+      <div class="program-card">
+        <div class="program-header">
+          <div class="program-icon"><i class="fab fa-linux"></i></div>
+          <div>
+            <h3>LFX Mentorship</h3>
+            <span class="program-subtitle">Critical Infrastructure Focus</span>
+          </div>
+        </div>
+        <p>Work on projects like Kubernetes, Linux Kernel, and Hyperledger with three annual cohorts. Highly technical and prestigious program with competitive stipends.</p>
+        <ul class="program-highlights">
+          <li><i class="fas fa-clock"></i> 12-24 weeks</li>
+          <li><i class="fas fa-dollar-sign"></i> $3,000-$6,600 stipend</li>
+          <li><i class="fas fa-server"></i> Advanced technical level</li>
+          <li><i class="fas fa-redo"></i> 3 terms per year</li>
+        </ul>
+        <div class="btn-container">
+          <a href="../library/guides_pdf/LFX Mentorship.pdf" class="btn btn-primary" target="_blank">
+            <i class="fas fa-file-pdf"></i> View Guide
+          </a>
+        </div>
+      </div>
+
+      <!-- Outreachy Card -->
+      <div class="program-card">
+        <div class="program-header">
+          <div class="program-icon"><i class="fas fa-hands-helping"></i></div>
+          <div>
+            <h3>Outreachy</h3>
+            <span class="program-subtitle">Diversity & Inclusion Focused</span>
+          </div>
+        </div>
+        <p>Three-month paid internships for people facing under-representation in tech, with a fixed $7,000 stipend. Two annual cohorts with mandatory contribution period.</p>
+        <ul class="program-highlights">
+          <li><i class="fas fa-clock"></i> 3 months duration</li>
+          <li><i class="fas fa-dollar-sign"></i> $7,000 USD fixed stipend</li>
+          <li><i class="fas fa-heart"></i> Diversity & inclusion</li>
+          <li><i class="fas fa-calendar-alt"></i> 2 cohorts annually</li>
+        </ul>
+        <div class="btn-container">
+          <a href="../library/guides_pdf/Outreachy.pdf" class="btn btn-primary" target="_blank">
+            <i class="fas fa-file-pdf"></i> View Guide
+          </a>
+        </div>
+      </div>
+
+      <!-- SSoC Card -->
+      <div class="program-card">
+        <div class="program-header">
+          <div class="program-icon"><i class="fas fa-hand-holding-heart"></i></div>
+          <div>
+            <h3>Social Summer of Code</h3>
+            <span class="program-subtitle">Social Impact Oriented</span>
+          </div>
+        </div>
+        <p>A beginner-friendly program focused on creating positive social impact through open source contributions. Features a tiered point system and rewards.</p>
+        <ul class="program-highlights">
+          <li><i class="fas fa-clock"></i> 2-3 months duration</li>
+          <li><i class="fas fa-certificate"></i> Certificates & badges</li>
+          <li><i class="fas fa-graduation-cap"></i> Student-tailored</li>
+          <li><i class="fas fa-chart-line"></i> Tiered point system</li>
+        </ul>
+        <div class="btn-container">
+          <a href="../library/guides_pdf/SSoC.pdf" class="btn btn-primary" target="_blank">
+            <i class="fas fa-file-pdf"></i> View Guide
+          </a>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer>
+    <p>
+      © 2026 OpenSource Compass ·
+      <a href="https://github.com/sayeeg-11/opensource-compass">GitHub</a> ·
+      Made with <i class="fas fa-heart" style="color: var(--primary-gold);"></i> for the Open Source Community
+    </p>
+  </footer>
+</body>
+</html>

--- a/frontend/pages/sitemap.html
+++ b/frontend/pages/sitemap.html
@@ -89,7 +89,7 @@
       <h2><i class="fa-solid fa-book"></i> Resources</h2>
       <ul>
         <li><a href="resources.html">Articles & Videos</a></li>
-        <li><a href="../library/guides_pdf/">PDF Guides</a></li>
+        <li><a href="pdf_guide.html">PDF Guides</a></li>
       </ul>
     </section>
 


### PR DESCRIPTION
## 📋 Description
This PR introduces a dedicated Guide page that aggregates all PDF guides for various open-source programs (GSoC, GSSoC, Hacktoberfest, LFX, Outreachy, etc.).

Previously, clicking "PDF Guides" from the sitemap redirected to a directory-style page without a proper UI. This change improves usability by providing a structured, user-friendly interface while keeping the existing theme consistent.

Fixes #347 
---

## 📸 Screenshots (MANDATORY for UI/UX changes)
🚨 If this PR includes any UI/UX changes, screenshots are REQUIRED.

<img width="1888" height="888" alt="Screenshot 2026-01-18 141120" src="https://github.com/user-attachments/assets/125b224b-326c-4cf1-a510-b44bd26d7361" />
<img width="1870" height="889" alt="Screenshot 2026-01-18 141131" src="https://github.com/user-attachments/assets/1a68ebe8-4477-46e3-8d0b-b0af629a1cf9" />
<img width="1884" height="890" alt="Screenshot 2026-01-18 141141" src="https://github.com/user-attachments/assets/09c553ca-2a33-4af1-8e28-ab5e49eabdc8" />


- [X] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

