### PR TITLE
feat: Added animated counters to stats section

### DIFF
--- a/frontend/js/home.js
+++ b/frontend/js/home.js
@@ -23,6 +23,70 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  // Stats counter animation
+  const statItems = document.querySelectorAll('.stat-item');
+  if (statItems.length && 'IntersectionObserver' in window) {
+    // Function to animate counter
+    function animateCounter(element, target, suffix, duration = 2000) {
+      const startTime = performance.now();
+      const startValue = 0;
+      
+      function updateCounter(currentTime) {
+        const elapsed = currentTime - startTime;
+        const progress = Math.min(elapsed / duration, 1);
+        
+        // Easing function for smooth animation
+        const easeOutQuart = 1 - Math.pow(1 - progress, 4);
+        const currentValue = Math.floor(easeOutQuart * target);
+        
+        element.textContent = currentValue + suffix;
+        
+        if (progress < 1) {
+          requestAnimationFrame(updateCounter);
+        } else {
+          // Ensure final value is exact
+          element.textContent = target + suffix;
+        }
+      }
+      
+      requestAnimationFrame(updateCounter);
+    }
+
+    // Create observer for stats
+    const statsObserver = new IntersectionObserver(
+      (entries, observer) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            const statItem = entry.target;
+            const numberElement = statItem.querySelector('h2');
+            
+            if (numberElement && !numberElement.hasAttribute('data-animated')) {
+              const target = parseFloat(numberElement.getAttribute('data-target') || '0');
+              const suffix = numberElement.getAttribute('data-suffix') || '';
+              
+              // Mark as animated to prevent re-running
+              numberElement.setAttribute('data-animated', 'true');
+              
+              // Start animation with small delay
+              setTimeout(() => {
+                animateCounter(numberElement, target, suffix);
+              }, 200);
+              
+              observer.unobserve(statItem);
+            }
+          }
+        });
+      },
+      { 
+        threshold: 0.3,
+        rootMargin: '0px 0px -100px 0px'
+      }
+    );
+
+    // Observe each stat item
+    statItems.forEach(item => statsObserver.observe(item));
+  }
+
   // Lightweight parallax: move only the visual block (not the whole hero)
   if (!prefersReducedMotion) {
     const heroVisual = document.querySelector('.hero-visual');

--- a/index.html
+++ b/index.html
@@ -177,28 +177,28 @@
         </div>
       </section>
 
+      <!-- Replace the existing stats section with this updated version -->
       <section class="stats">
         <h3>Open Source Impact</h3>
         <div class="stats-grid">
           <div class="stat-item fade-in">
-            <h2>50K+</h2>
+            <h2 data-target="50" data-suffix="K+">0</h2>
             <p>First Contributions</p>
           </div>
           <div class="stat-item fade-in">
-            <h2>200+</h2>
+            <h2 data-target="200" data-suffix="+">0</h2>
             <p>Programs Tracked</p>
           </div>
           <div class="stat-item fade-in">
-            <h2>10K+</h2>
+            <h2 data-target="10" data-suffix="K+">0</h2>
             <p>Active Mentors</p>
           </div>
           <div class="stat-item fade-in">
-            <h2>5Y+</h2>
+            <h2 data-target="5" data-suffix="Y+">0</h2>
             <p>Proven Track Record</p>
           </div>
         </div>
       </section>
-
       <section class="programs" id="programs">
         <h3>Legendary Open Source Programs</h3>
         <p>Curated programs with historical success rates and maintainer insights.</p>


### PR DESCRIPTION
## 📋 Description
This PR adds animated counters to the "Open Source Impact" stats section.

Changes included:
- Numbers now animate from 0 to their target values on scroll
- Uses pure frontend JavaScript (no backend, no library)
- Lightweight scroll-based trigger
- Preserves suffixes like K+, +, and Y+

Fixes #382

---

## 📸 Screenshots (I HAVE PASTED A VIDEO FOR THE ANIMATIOIN CHECKOUT)

https://github.com/user-attachments/assets/4a403213-9993-4f42-9f25-5143e01f6aba



- [X] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

