### PR TITLE
Fix card alignment and enforce equal dimensions

### DIFF
--- a/frontend/css/guides.css
+++ b/frontend/css/guides.css
@@ -389,11 +389,14 @@
   max-width: 700px;
   margin: 1rem auto 3rem;
 }
+
 .practices-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(220px, 1fr)); /* Minimum width so cards don’t shrink too much */
-  gap: 2.5rem;
-  text-align: left;
+  grid-template-columns: repeat(4, 1fr); /* force single row */
+  gap:20px;
+  width: 100%;   /* adjust if needed */
+  margin: 0 auto;     /* center horizontally */
+  align-items: stretch;
 }
 
 
@@ -418,10 +421,16 @@
   padding: 2rem;
   box-shadow: var(--shadow-main);
   transition: transform 0.35s ease, box-shadow 0.35s ease;
+  gap: 1rem;
   display: flex;
   flex-direction: column;
+  justify-content: space-between; /* equal vertical spacing */
+  text-align: center;
   align-items: center;
-  gap: 1rem;
+  padding: 2rem;
+
+  /* 🔥 force equal size */
+  height: 100%;
 }
 
 .practice-item:hover {


### PR DESCRIPTION
Fixes #501 

This PR is submitted under Social Winter of Code (SWOC)

## 📋 Description
This PR improves the layout of the “Best Practices for Contributing” section by fixing card alignment and sizing issues.
Previously, the cards appeared visually unbalanced due to inconsistent widths and heights, which affected overall UI consistency and polish.

Before
<img width="1892" height="917" alt="image" src="https://github.com/user-attachments/assets/ee8a6aad-62bd-4849-b633-3c4eb88e7ce2" />
 
After
<img width="1896" height="873" alt="image" src="https://github.com/user-attachments/assets/6fdce239-c8c2-4fcf-b6ff-0cef679207d4" />


- [x] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes
