### PR TITLE
Fix navbar link contrast in dark mode

### DIFF
--- a/frontend/css/navigation.css
+++ b/frontend/css/navigation.css
@@ -44,3 +44,44 @@
     display: none;
     z-index: 1001;
 }
+
+/* ===== Dark mode navigation fixes ===== */
+
+.dark-mode .nav-sidebar {
+    background: #0f172a;           /* dark slate */
+    border-right: 1px solid #1e293b;
+}
+
+.dark-mode .nav-sidebar a {
+    color: #e5e7eb;                /* readable light gray */
+    opacity: 1;
+}
+
+.dark-mode .nav-sidebar a:hover {
+    background: #1e293b;
+    color: #ffffff;
+}
+
+.dark-mode .nav-sidebar a.active {
+    background: #1e293b;
+    color: #60a5fa;                /* soft blue accent */
+    font-weight: 600;
+}
+
+/* Breadcrumbs in dark mode */
+
+.dark-mode .breadcrumb {
+    color: #9ca3af;
+}
+
+.dark-mode .breadcrumb a {
+    color: #93c5fd;
+}
+
+/* Search dropdown dark mode */
+
+.dark-mode #searchResults {
+    background: #0f172a;
+    color: #e5e7eb;
+    box-shadow: 0 10px 25px rgb(0 0 0 / 40%);
+}


### PR DESCRIPTION
### Problem
Navigation links in dark mode had very low contrast and were hard to read.

### Solution
- Increased link color brightness in dark mode
- Removed opacity reduction
- Improved hover contrast

### Result
Navbar links are now clearly visible and accessible in dark mode.

### Before
<img width="1440" height="703" alt="Screenshot 2026-01-22 at 10 29 10 AM" src="https://github.com/user-attachments/assets/07844104-cab9-4c98-a065-1e0d6895e276" />

### After

<img width="1452" height="749" alt="Screenshot 2026-01-27 at 8 11 14 PM" src="https://github.com/user-attachments/assets/25ec9e94-1b0c-4c11-972f-ad4cf311c994" />

