### PR TITLE
fix/chatbot and scrollToTop overlap

### DIFF
--- a/frontend/css/chatbot.css
+++ b/frontend/css/chatbot.css
@@ -22,8 +22,8 @@ body.dark-mode {
 /* Floating Chat Button */
 .chat-widget-btn {
     position: fixed;
-    bottom: 2rem;
-    right: 2rem;
+    bottom: 7rem;
+    right: 1rem;
     /* CHANGE: Blue -> Golden Gradient */
     background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
     color: var(--deep-navy);


### PR DESCRIPTION
Fixes #522 

## 📋 Description
On the Resources page, the **Quick Assistance Chat with AI** button overlaps with the **Back to Top** button when scrolling. This causes UI clutter and reduces click accessibility.

- Adjusted the fixed positioning of floating buttons
- Ensured both buttons have separate, non-overlapping positions
- Maintained responsiveness across screen sizes

---

## 📸 Screenshots (MANDATORY for UI/UX changes)

<img width="1872" height="836" alt="image" src="https://github.com/user-attachments/assets/3fe79926-e411-41ef-99c7-f23128329940" />


<!-- Drag & drop screenshots below -->

- [x] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

I am a SWoC’26 Contributor and would be happy to make further refinements if suggested