### PR TITLE
Fix: Dark mode rendering failure on Contributors page heading

### DIFF
--- a/frontend/pages/contributors.html
+++ b/frontend/pages/contributors.html
@@ -6,7 +6,6 @@
   <link rel="icon" href="../library/assets/favicon.png" type="image/png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <!-- Font Awesome (REQUIRED for logo) -->
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
@@ -17,10 +16,28 @@
     rel="stylesheet"
   />
 
-  <!-- Global CSS -->
   <link rel="stylesheet" href="../css/style.css" />
   <link rel="stylesheet" href="../css/contributors.css" />
   <link rel="stylesheet" href="../css/chatbot.css" /> 
+
+  <style>
+    /* Dynamic Dark Mode Styling for the Heading 
+       Matches the "Why OpenSource Compass" gradient from home.css 
+    */
+    body.dark-mode .contributors-section h3 {
+      background: linear-gradient(
+        135deg,
+        #ffffff 0%,
+        var(--primary-gold) 55%,
+        var(--secondary-gold) 100%
+      );
+      background-clip: text;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      font-weight: 800;
+      letter-spacing: -0.015em;
+    }
+  </style>
 </head>
 
 


### PR DESCRIPTION
## 📋 Description

- This PR resolves a defect where the "Contributors" page heading failed to update its state when switching the application to dark mode. The element persisted in its default state (black text), causing a visibility failure against the dark background.



## The Issue

- **Behavior:** When the dark-mode class is active on the <body>, the <h3> heading "Contributors" does not inherit the correct theme variables. It remains black (#000), resulting in near-zero contrast against the dark background (#0b1220).

- **Cause:** Missing CSS rule set for the dark-mode state specifically for the contributors section heading, preventing it from matching the global design system (golden gradient).

## The Fix

- Implemented a targeted CSS rule for body.dark-mode .contributors-section h3.

- Applied the correct gradient logic (linear-gradient(135deg, ...)) and background-clip properties to match the "Why OpenSource Compass" component from the index page.

- Ensured the heading text is now readable and consistent with the application's dark theme logic.

## How to Test

1. Checkout this branch.

2. Open frontend/pages/contributors.html.

3. Click the theme toggle to switch to Dark Mode.

4. Verify: The "Contributors" heading is now clearly visible and displays the golden gradient texture instead of solid black.

## 📸 Screenshots (After): 

https://github.com/user-attachments/assets/4a2c9739-fb8e-4b21-95d3-2a57bfeb03ef

## Solves issue number: #512 