### PR TITLE
[feature] : Add Smart Issue Claiming workflow with auto-assign

### DIFF
--- a/.github/workflows/issue-claim.yml
+++ b/.github/workflows/issue-claim.yml
@@ -1,0 +1,137 @@
+name: Smart Issue Claiming
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  claim-handler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const commentBody = context.payload.comment?.body;
+
+            if (!issue || issue.pull_request || !commentBody) return;
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const actor = context.actor;
+            const text = commentBody.trim().toLowerCase();
+
+            const labels = issue.labels.map(l => l.name);
+            const isAlreadyClaimed = labels.includes('claimed');
+
+            // -------- PHRASES --------
+            const claimPhrases = [
+              '/claim',
+              'i want to work on this',
+              'i will work on this',
+              'i will take this issue',
+              'can i work on this',
+              'assign this to me',
+              'i am taking this issue'
+            ];
+
+            const unclaimPhrases = [
+              '/unclaim',
+              'i am no longer working on this',
+              'i want to unclaim this',
+              'unassign me',
+              'i am dropping this issue'
+            ];
+
+            const isClaim = claimPhrases.some(p => text === p || text.includes(p));
+            const isUnclaim = unclaimPhrases.some(p => text === p || text.includes(p));
+
+            // -------- CHECK ASSIGNEES --------
+            const currentAssignees = issue.assignees ? issue.assignees.map(a => a.login) : [];
+
+            // -------- CLAIM --------
+            if (isClaim) {
+              if (isAlreadyClaimed || currentAssignees.length > 0) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: `⚠️ This issue is already claimed by @${currentAssignees.length > 0 ? currentAssignees.join(', @') : 'someone'}.`
+                });
+                return;
+              }
+
+              // Add claimed label
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issue.number,
+                labels: ['claimed']
+              });
+
+              // Assign GitHub issue to claimer
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: issue.number,
+                assignees: [actor]
+              });
+
+              // Confirmation comment
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: `✅ @${actor} is now working on this issue.`
+              });
+
+              return;
+            }
+
+            // -------- UNCLAIM (CLAIMER ONLY) --------
+            if (isUnclaim) {
+              if (!isAlreadyClaimed) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: `ℹ️ This issue is not currently claimed.`
+                });
+                return;
+              }
+
+              if (currentAssignees.length > 0 && !currentAssignees.includes(actor)) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: `⛔ Only @${currentAssignees.join(', @')} can unclaim this issue.`
+                });
+                return;
+              }
+
+              // Remove claimed label
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: issue.number,
+                name: 'claimed'
+              });
+
+              // Remove assignee
+              await github.rest.issues.removeAssignees({
+                owner,
+                repo,
+                issue_number: issue.number,
+                assignees: [actor]
+              });
+
+              // Confirmation comment
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: `🔓 @${actor} has unclaimed this issue. It is now available.`
+              });
+            }


### PR DESCRIPTION
- closes #322

This PR adds a Smart Issue Claiming workflow to automate GitHub issue management.
#### Features include:
  - Claim/unclaim issues via slash commands or plain-English phrases
  - Auto-assign GitHub assignee to the claimer
  - Claimer-only unclaim to prevent accidental unclaims
  - Prevents claiming issues that are already claimed
  
## Impact

- Ensures clear ownership of issues and reduces conflicts
- Streamlines collaboration, making it easy for contributors to claim tasks
- Saves maintainers time by automating labeling and assignment
- Improves transparency on who is working on which issue

#### This pull request is submitted as part of SWoC 2026. Thank you for taking the time to review this contribution!