### PR TITLE
Fix dark mode contrast on Guides page and correct invalid HTML

### DIFF
--- a/frontend/css/guides.css
+++ b/frontend/css/guides.css
@@ -788,3 +788,51 @@ html {
     grid-template-columns: 1fr;
   }
 }
+
+/* =====================================================
+   Dark Mode Refinement – Guides Page (Final Patch)
+   Paste at the bottom of guides.css
+===================================================== */
+
+/* Section surfaces */
+.dark-mode .guides-hero,
+.dark-mode .guides-section {
+  background-color: #020617; /* deep slate for contrast */
+}
+
+/* Headings */
+.dark-mode .guides-section h1,
+.dark-mode .guides-section h2,
+.dark-mode .guides-section h3 {
+  color: #f8fafc;
+}
+
+/* Body text */
+.dark-mode .guides-section p {
+  color: #cbd5f5;
+}
+
+/* Guide cards */
+.dark-mode .guide-card {
+  background-color: #111827;
+  border: 1px solid #1f2937;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.65);
+}
+
+/* Card titles & content */
+.dark-mode .guide-card h3,
+.dark-mode .guide-card p {
+  color: #e5e7eb;
+}
+
+/* Number badge / icon */
+.dark-mode .guide-card .number {
+  background-color: #fbbf24;
+  color: #111827;
+}
+
+/* Hover polish */
+.dark-mode .guide-card:hover {
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.75);
+  transform: translateY(-2px);
+}

--- a/index.html
+++ b/index.html
@@ -495,8 +495,8 @@
     <b>🎥Video for Beginners 🌟 "Start" your First Contribution</b>
 
 
-    <div style="
-      </div>
+    <div></div>
+   </section>
     </section>
 
     </div>


### PR DESCRIPTION
### Summary
Fixes a dark mode contrast issue on the Guides page where text and cards were difficult to read.

### Changes
- Added explicit dark-mode styles for Guides section background, text, and cards
- Improved visual separation and readability in dark mode
- Fixed invalid HTML markup (unclosed inline style) without changing behavior

### Context
This issue only affected dark mode; light mode remains unchanged.

###Screenshot Attached
<img width="1466" height="753" alt="Screenshot 2026-02-02 at 6 16 37 PM" src="https://github.com/user-attachments/assets/fd5993b4-446a-4e4d-b16f-1cc1f9e8b373" />

Fixes #623 
