### PR TITLE
Add more common beginner mistakes to Guides section

### DIFF
--- a/frontend/pages/guides.html
+++ b/frontend/pages/guides.html
@@ -210,6 +210,22 @@
       <span class="mistake-icon">4</span>
       <p>Not testing changes before submitting</p>
     </li>
+        <li>
+      <span class="mistake-icon">5</span>
+      <p>Opening issues or pull requests without checking for duplicates</p>
+    </li>
+    <li>
+      <span class="mistake-icon">6</span>
+      <p>Ignoring or misunderstanding maintainers’ feedback</p>
+    </li>
+    <li>
+      <span class="mistake-icon">7</span>
+      <p>Making large or breaking changes without prior discussion</p>
+    </li>
+    <li>
+      <span class="mistake-icon">8</span>
+      <p>Poor or unclear pull request descriptions</p>
+    </li>
   </ul>
 </section>
 


### PR DESCRIPTION
## 📋 Description
Summary
This PR enhances the “Common Mistakes Beginners Should Avoid” section by adding several frequently encountered beginner pitfalls that were previously missing.

What’s Changed
Added the following common mistakes to improve guidance for first-time contributors:
Opening issues or pull requests without checking for duplicates
Ignoring or misunderstanding maintainers’ feedback
Making large or breaking changes without prior discussion
Writing poor or unclear pull request descriptions

## 📸 Screenshots (MANDATORY for UI/UX changes)
<img width="1919" height="961" alt="Screenshot 2026-02-02 201740" src="https://github.com/user-attachments/assets/7cdc6e76-d997-4e64-b33d-3f8f9b109455" />


- [x] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

Fixes #615 