### PR TITLE
Fix contributors stats filter logic to not affect the top contributor 

### DIFF
--- a/frontend/css/contributors.css
+++ b/frontend/css/contributors.css
@@ -5,18 +5,29 @@
   max-width: 1200px;
   margin: 0 auto;
   padding: 3rem 1.5rem;
+  text-align: center;
 }
 
-.contributors-section h3 {
+.contributors-section h1 {
   font-size: 2rem;
   font-weight: 700;
   margin-bottom: 0.4rem;
+  margin-top: 0.4rem;
+  color: var(--deep-navy);
+}
+
+body.dark-mode .contributors-section h1 {
+  color: #d2c917;
 }
 
 .contributors-section p {
   color: var(--text-secondary);
   margin-bottom: 1.5rem;
   max-width: 620px;
+}
+
+body.dark-mode .contributors-section p {
+  color: #9ca3af;
 }
 
 /* ---------- Stats ---------- */
@@ -64,7 +75,7 @@
   align-items: center;
   gap: 0.4rem;
   font-size: 0.9rem;
-  color: var(--text-secondary);
+  color: var(--contributors-text);
   cursor: pointer;
 }
 
@@ -648,14 +659,14 @@ body.dark-mode .sk {
   gap: 0.6rem;
   padding: 0.65rem 1.2rem;
   border-radius: 999px;
-  background: linear-gradient(180deg, #ffffff, #fafafa);
-  border: 1px solid #e6e6e6;
+  background: #ffffff;
+  border: 1px solid var(--contributors-border);
+  color: var(--contributors-text);
   box-shadow:
     0 6px 14px rgba(0, 0, 0, 0.06),
     inset 0 1px 0 rgba(255, 255, 255, 0.7);
   font-size: 0.85rem;
   font-weight: 600;
-  color: #1b263b;
   white-space: nowrap;
 
   /* load animation */
@@ -671,17 +682,18 @@ body.dark-mode .sk {
 .stat-pill.stat-top     { animation-delay: 0.25s; }
 
 /* Label */
-.stat-label {
+.contributors-stats .stat-label {
   font-size: 0.8rem;
   font-weight: 600;
   color: #1b263b;
+  padding: 0.5rem;
 }
 
-/* 🔥 GOLD NUMBER BADGE (replaces blue) */
-.stat-count {
+/* 🔥 GOLD NUMBER BADGE */
+.contributors-stats .stat-count {
   padding: 0.3rem 0.7rem;
   border-radius: 999px;
-  background-color: #f4d49a; 
+  background-color: #d4af37; 
   color: #3a2a00;
   font-size: 0.75rem;
   font-weight: 700;
@@ -693,9 +705,9 @@ body.dark-mode .sk {
 ========================================= */
 
 .stat-pill.stat-top {
-  background: linear-gradient(180deg, #fff7dd, #fdeeb5);
+  background: linear-gradient(180deg, #e6c453, #fdeeb5);
   border-color: #d4af37;
-  color: #8a6a00;
+  color: #634c00;
   font-weight: 700;
   box-shadow:
     0 10px 24px rgba(212, 175, 55, 0.35),
@@ -794,14 +806,14 @@ body.dark-mode .sk {
 ========================================= */
 
 body.dark-mode .stat-pill {
-  background: linear-gradient(180deg, #1e1e1e, #191919);
-  border-color: #333;
-  color: #e6e6e6;
+  background: linear-gradient(180deg, #ffffff, #ffe9a9);
+  border-color: #d5c63e;
+  color: #a13636;
   box-shadow: 0 6px 14px rgba(0,0,0,0.5);
 }
 
 body.dark-mode .stat-label {
-  color: #e6e6e6;
+  color: #000000;
 }
 
 /* Gold still pops in dark mode */
@@ -817,7 +829,7 @@ body.dark-mode .stat-pill.stat-top {
 }
 
 body.dark-mode .bot-toggle {
-  color: #e0e0e0;
+  color: #f5d77a;
 }
 
 body.dark-mode #contributor-search {

--- a/frontend/js/contributors.js
+++ b/frontend/js/contributors.js
@@ -481,8 +481,7 @@ function updateStats(list, allList = allContributors) {
       top
         ? `
       <div class="stat-pill stat-top">
-        <span class="trophy">🏆</span>
-        <span class="stat-label">Top:</span>
+        <span class="stat-label"> 🏆 Top:</span>
         <strong>${escapeHtml(top.login)}</strong>
       </div>
     `

--- a/frontend/pages/contributors.html
+++ b/frontend/pages/contributors.html
@@ -10,7 +10,6 @@
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
   />
-<link rel="stylesheet" href="/frontend/css/dark-mode.css">
   <link
     href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Crimson+Text:wght@400;600&family=Inter:wght@400;500;600&display=swap"
     rel="stylesheet"
@@ -27,7 +26,7 @@
 
   <main>
     <section class="contributors-section">
-      <h3>Contributors</h3>
+      <h1>Contributors</h1>
       <p>People who have helped build and improve OpenSource Compass.</p>
 
       <div class="contributors-stats" id="contributors-stats"></div>


### PR DESCRIPTION
Fixes #622 

### Description
The top contributor badge was changing when users searched or toggled bot filters.
This PR ensures the top contributor is always derived from the complete contributors list,
while other stats (counts and merged PRs) remain filter-aware.

### Changes Made
- Decoupled top contributor calculation from filtered results
- Preserved global contributor ranking during UI filtering

### Screenshots
Before: Top contributor changed after search  
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/610fef39-1745-4ae7-88c1-86dba6e96b32" />

After: Top contributor remains consistent
<img width="1920" height="1016" alt="image" src="https://github.com/user-attachments/assets/19fcf27b-bdc2-453d-af35-fde669db06b7" />

- [x] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

@sayeeg-11 Please review,
I have worked on this under `SWoC26`..!