### PR TITLE
fix contribution page alignment

### DIFF
--- a/frontend/css/contributors.css
+++ b/frontend/css/contributors.css
@@ -24,10 +24,12 @@ body.dark-mode .contributors-section h1 {
   color: var(--text-secondary);
   margin-bottom: 1.5rem;
   max-width: 620px;
+  margin-left: 25%;
 }
 
 body.dark-mode .contributors-section p {
   color: #9ca3af;
+
 }
 
 /* ---------- Stats ---------- */


### PR DESCRIPTION
## 📋 Description
Fix the frontend/pages/contributors.html page misalignment of 
the text " People who have helped build and improve OpenSource Compass."

fixes #731 


---

## 📸 Screenshots (MANDATORY for UI/UX changes)
<img width="1866" height="415" alt="image" src="https://github.com/user-attachments/assets/9e8b3d91-8e94-48b7-a03b-8bd8270a3fce" />

<!-- Drag & drop screenshots below -->

- [ x] This PR includes UI/UX changes → Screenshots attached

If screenshots are not applicable, explain briefly: