### PR TITLE
fix: redirect Apply Now button to official LFX application page

### DIFF
--- a/frontend/pages/Event/linux.html
+++ b/frontend/pages/Event/linux.html
@@ -1051,7 +1051,7 @@
                 </p>
 
                 <div class="hero-actions">
-                    <a href="#apply" class="btn primary">Apply Now</a>
+                    <a href="https://lfx.linuxfoundation.org/tools/mentorship/" target="_blank" class="btn primary">Apply Now</a>
                     <a href="#about" class="btn secondary">Explore Program</a>
                 </div>
 
@@ -1460,7 +1460,7 @@
             </div>
 
             <div class="apply-cta">
-                <a href="#apply-form" class="btn primary">Apply Now</a>
+                <a href="https://lfx.linuxfoundation.org/tools/mentorship/" target="_blank" class="btn primary">Apply Now</a>
                 <a href="#contact" class="btn secondary">Contact Support</a>
             </div>
 


### PR DESCRIPTION
## 📋 Description

This PR fixes the issue where the "Apply Now" button on the Linux Foundation Mentorship Program page was not redirecting users to the official LFX application page.

Previously, clicking the button either did nothing or kept the user on the same page without navigation. This caused confusion for applicants trying to proceed with their application.

The button has now been updated to correctly redirect users to the official LFX mentorship application page in a new tab.

Fixes #772

---

## 📸 Screenshots (MANDATORY for UI/UX changes)

- [x] This PR does NOT include UI/UX changes

If screenshots are not applicable, explain briefly:
This change only updates the redirection link of the button and does not modify the UI layout or design.
