### PR TITLE
Add navbar dark-mode toggle

### DIFF
--- a/frontend/pages/Event/gssoc.html
+++ b/frontend/pages/Event/gssoc.html
@@ -10,6 +10,11 @@
         content="Complete guide to GirlScript Summer of Code (GSSOC) - Learn about program structure, benefits, and how to apply for this beginner-friendly open source program.">
 
     <link rel="stylesheet" href="../../css/style.css">
+    <link rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+  integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
+  crossorigin="anonymous" referrerpolicy="no-referrer" />
+
 
     <style>
         :root {
@@ -2047,9 +2052,10 @@
                 <a href="../faq.html">FAQ</a>
                 <a href="../Contribute.html">Contribute</a>
                 <button id="themeToggle" aria-label="Toggle dark mode" title="Toggle dark mode"
-                    style="background: none; border: none; color: var(--primary-gold); cursor: pointer; font-size: 1.1rem; margin-left: 0.5rem; transition: transform 0.3s ease;">
-                    <i class="fas fa-moon" aria-hidden="true"></i>
-                </button>
+  style="background: none; border: none; color: var(--primary-gold); cursor: pointer; font-size: 1.1rem; margin-left: 0.5rem; transition: transform 0.3s ease;">
+  <i class="fas fa-moon" aria-hidden="true"></i>
+</button>
+
             </div>
         </div>
     </header>
@@ -2474,27 +2480,6 @@
     <script src="../../js/DMtheme.js"></script>
 
     <script src="../../js/theme.js"></script>
-
-      <div class="protip-card">
-        <div class="protip-index">05</div>
-        <h3>Document Your Work</h3>
-        <p>
-          Maintain proper documentation and comments so your contributions
-          remain valuable and reusable.
-        </p>
-      </div>
-
-      <div class="protip-card">
-        <div class="protip-index">06</div>
-        <h3>Engage With the Community</h3>
-        <p>
-          Participate in discussions, help others, and build meaningful
-          connections within the SSOC community.
-        </p>
-      </div>
-
-    </div>
-
   </div>
 </section>
 


### PR DESCRIPTION
## 📋 Description

- Integrated Font Awesome CDN in the <head> for using moon/sun icons in the navbar toggle.
- Removed unnecessary cards/sections that were rendered below the footer to keep the layout clean and focused.


---

## 📸 Screenshots (MANDATORY for UI/UX changes)
🚨 If this PR includes any UI/UX changes, screenshots are REQUIRED.

<img width="1920" height="847" alt="image" src="https://github.com/user-attachments/assets/90afe97b-4cc1-4254-9dce-f0fc54764b85" />


- [x] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

If screenshots are not applicable, explain briefly:


Closes #700 