### PR TITLE
Contributors page heading aligned correctly

### DIFF
--- a/frontend/css/contributors.css
+++ b/frontend/css/contributors.css
@@ -15,6 +15,18 @@
   margin-top: 0.4rem;
   color: var(--deep-navy);
 }
+.contributors-section {
+  padding-top:80px;   /* ensures it clears navbar */
+  text-align: center;   /* center everything */
+}
+
+.contributors-section h1 {
+  font-size: 2.5rem;
+  margin-bottom: 10px;
+  text-align: center;
+  width: 100%;
+  display: block;
+}
 
 body.dark-mode .contributors-section h1 {
   color: #d2c917;


### PR DESCRIPTION
@sayeeg-11 , I've completed my work, pls review it. Issue fix #731
Before modifying,
<img width="1773" height="381" alt="Screenshot 2026-02-14 191455" src="https://github.com/user-attachments/assets/1b44d531-697f-4610-b056-01c59b01e18b" />

After modifying,
<img width="1884" height="906" alt="Screenshot 2026-02-14 192352" src="https://github.com/user-attachments/assets/2f0147d2-997a-4cc2-9ece-4fec5383ffb5" />
