### PR TITLE
Fix hero image path

### DIFF
--- a/frontend/pages/Event/linux.html
+++ b/frontend/pages/Event/linux.html
@@ -1073,7 +1073,7 @@
 
             <div class="hero-visual">
                 <div class="glow"></div>
-                <img src="linux-hero.svg" alt="Linux Open Source" />
+                <img src="../../library/assets/program_logo/linux.webp" alt="Linux Open Source" />
             </div>
 
         </div>


### PR DESCRIPTION
## 📋 Description
This PR fixes the broken hero image on the Linux Foundation Mentorship (LFX) page.

The page previously referenced an image file that did not exist in the library/assets directory, resulting in a 404 error and a broken image icon in the browser.

Changes made:
	•	Updated the img source path to correctly reference the existing asset

### Screenshots
Before
<img width="1462" height="760" alt="Screenshot 2026-02-16 at 6 26 54 PM" src="https://github.com/user-attachments/assets/fc30fc3e-7430-44d0-864c-2ca82489a533" />
After
<img width="1460" height="763" alt="Screenshot 2026-02-16 at 6 52 18 PM" src="https://github.com/user-attachments/assets/069dcd40-abf8-49d2-9035-1f79a1b3f7e3" />

Fixes #816 