### PR TITLE
Fix News Letter Contrast in Light Mode

### DIFF
--- a/index.css
+++ b/index.css
@@ -737,7 +737,7 @@ body {
   --border-color: #e2d1a8;
   --primary-gold: #b59d5c;
   --shadow: rgba(0, 0, 0, 0.05);
-  --newsletter-bg: #fcfbf7;        /* Light cream */
+  --newsletter-bg: #b5b1a0;        /* Light cream */
   --newsletter-card: #ffffff;      /* Pure white */
   --newsletter-text-h: #1a1a1a;    /* Deep navy/black */
   --newsletter-text-p: #555555;    /* Gray */


### PR DESCRIPTION
## 📋 Description
Earlier In light Mode of News Letter section the text written was not visible due to color contrast changed that and made it visible.
---
Fixes #785 

## 📸 Screenshots (MANDATORY for UI/UX changes)
<img width="1909" height="915" alt="image" src="https://github.com/user-attachments/assets/75497e62-4965-4a49-8c98-5af5620976ee" />




- [x] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

