### PR TITLE
Fix dark mode background override issue on Guides page

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -2124,3 +2124,7 @@ body.dark-mode .newsletter-section input {
   color: #ffffff !important;
   border: 1px solid #555 !important;
 }
+
+body.dark-mode {
+  background: #121212 !important;
+}


### PR DESCRIPTION
Fixes: #837 

## 📋 Description
This PR fixes the unintended gradient background appearing in Dark Mode on the Guides page.

## What was fixed?
• Overrode the global gradient in Dark Mode
• Forced a solid black background for both html and body
• Ensured no background bleed from root gradient variables

## 📸 Screenshots 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3307428e-040a-454b-a60d-896101cb8ead" />

- [x] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

---

Note:
I have worked on this under `SWoC26`..!
@sayeeg-11, Please review...