### PR TITLE
feat: add multiline auto-resizing input to chatbot with Enter/Shift+Enter nextline

### DIFF
--- a/frontend/css/chatbot.css
+++ b/frontend/css/chatbot.css
@@ -232,11 +232,20 @@ body.dark-mode .chat-input-area {
 
 #chatInput {
     flex: 1;
-    padding: 0.8rem;
+    padding: 10px 14px;
     border: 1px solid #ddd;
-    border-radius: 25px;
+    border-radius: 16px;
     outline: none;
     font-family: inherit;
+    font-size: 14px;
+    resize: none;              /* Disable manual resize */
+    overflow-y: auto;          /* Scroll if max reached */
+    line-height: 1.4;
+    min-height: 40px;
+    max-height: 120px;         /* Prevents layout breaking */
+    transition: border 0.2s ease;
+    background: var(--chat-bg);
+    color: var(--chat-text);
 }
 
 #chatInput:focus {

--- a/frontend/js/chatbot.js
+++ b/frontend/js/chatbot.js
@@ -17,16 +17,16 @@ document.addEventListener('DOMContentLoaded', () => {
             <button class="close-btn">&times;</button>
         </div>
         <div class="chat-messages" id="chatMessages">
-    <div class="message bot">
-        Hello! I'm here to help you with your open source journey. Ask me anything!
-    </div>
-</div>
-<div class="typing-indicator" id="typingIndicator" style="display: none;">
-    OpenSource Guide is typing...
-</div>
+            <div class="message bot">
+                Hello! I'm here to help you with your open source journey. Ask me anything!
+            </div>
+        </div>
+        <div class="typing-indicator" id="typingIndicator" style="display: none;">
+            OpenSource Guide is typing...
+        </div>
 
         <div class="chat-input-area">
-            <input type="text" id="chatInput" placeholder="Type a message...">
+            <textarea id="chatInput" rows="1" placeholder="Type a message..."></textarea>
             <button id="sendBtn">➤</button>
         </div>
     `;
@@ -82,6 +82,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Add User Message
         addMessage(text, 'user');
         chatInput.value = '';
+        chatInput.style.height = "auto";
 
         // Process Bot Response
         // Simulate thinking time
@@ -101,8 +102,18 @@ setTimeout(() => {
     }
 
     sendBtn.addEventListener('click', sendMessage);
-    chatInput.addEventListener('keypress', (e) => {
-        if (e.key === 'Enter') sendMessage();
+    // Auto resize textarea
+    chatInput.addEventListener("input", function () {
+        this.style.height = "auto";
+        this.style.height = this.scrollHeight + "px";
+    });
+
+    // Enter to send | Shift+Enter for new line
+    chatInput.addEventListener("keydown", function (e) {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            sendMessage();
+        }
     });
 
     function getCurrentTime() {


### PR DESCRIPTION
Fixes: #895 

## 📋 Description

This PR enhances the chatbot input field to support multiline messages for better user experience.

-- Converted chatbot input from a single-line input field to a multiline textarea.
-- Implemented smooth auto-height resizing as the user types.
-- Added keyboard controls:
-- Enter → Sends the message.
-- Shift + Enter → Adds a new line.
-- Reset textarea height after sending a message to maintain layout consistency.

Why This Change?

-- Previously, the chatbot only supported single-line messages, limiting usability for longer or structured queries.
-- This update improves UX by allowing users to type detailed and formatted messages naturally.
---

## 📸 Screenshots 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a3ba6094-aab6-4282-9944-21c11148f46c" />


- [x] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

---

Note: I have worked on this under `SWoC26`..!
@sayeeg-11 please review...