### PR TITLE
feat: add quick suggestion chips to chatbot for improved user guidance

### DIFF
--- a/frontend/css/chatbot.css
+++ b/frontend/css/chatbot.css
@@ -272,3 +272,32 @@ body.dark-mode .chat-input-area {
     background: var(--primary-gold);
     color: var(--deep-navy);
 }
+
+.suggestions {
+display: flex;
+flex-wrap: wrap;
+gap: 8px;
+margin-top: 10px;
+}
+
+.suggestion-chip {
+background: white;
+border: 1px solid var(--primary-gold);
+color: var(--deep-navy);
+padding: 6px 12px;
+border-radius: 20px;
+font-size: 12px;
+cursor: pointer;
+transition: all 0.2s ease;
+}
+
+.suggestion-chip:hover {
+background: var(--primary-gold);
+color: var(--deep-navy);
+transform: translateY(-2px);
+}
+
+body.dark-mode .suggestion-chip {
+background: var(--chat-bot-msg-bg);
+color: var(--chat-text);
+}

--- a/frontend/js/chatbot.js
+++ b/frontend/js/chatbot.js
@@ -20,6 +20,9 @@ document.addEventListener('DOMContentLoaded', () => {
             <div class="message bot">
                 Hello! I'm here to help you with your open source journey. Ask me anything!
             </div>
+            <div class="suggestions" id="chatSuggestions">
+                <!-- Chips will be injected here -->
+            </div>
         </div>
         <div class="typing-indicator" id="typingIndicator" style="display: none;">
             OpenSource Guide is typing...
@@ -39,10 +42,38 @@ document.addEventListener('DOMContentLoaded', () => {
     const chatInput = document.getElementById('chatInput');
     const messagesContainer = document.getElementById('chatMessages');
     const typingIndicator = document.getElementById('typingIndicator');
+    const suggestionsContainer = document.getElementById("chatSuggestions");
 
 
     let intents = [];
 
+    const suggestions = [
+        "Know about Open Source",
+        "Beginner Guide",
+        "Git Push Command",
+        "How to Raise a PR",
+        "Contribution Guide"
+    ];
+
+    function renderSuggestions() {
+        suggestionsContainer.innerHTML = "";
+        suggestions.forEach(text => {
+            const chip = document.createElement("button");
+            chip.className = "suggestion-chip";
+            chip.textContent = text;
+
+            chip.addEventListener("click", () => {
+                chatInput.value = text;
+                sendMessage();
+                suggestionsContainer.style.display = "none"; // hide after click
+            });
+
+            suggestionsContainer.appendChild(chip);
+        });
+    }
+
+    renderSuggestions();
+    
     // Load data
     // Note: This path assumes index.html is in /pages/ and data is in /data/
     fetch('../data/chatbot_data.json')
@@ -87,17 +118,17 @@ document.addEventListener('DOMContentLoaded', () => {
         // Process Bot Response
         // Simulate thinking time
         // Show typing indicator
-typingIndicator.style.display = 'block';
-messagesContainer.scrollTop = messagesContainer.scrollHeight;
+        typingIndicator.style.display = 'block';
+        messagesContainer.scrollTop = messagesContainer.scrollHeight;
 
-// Simulate thinking time
-setTimeout(() => {
-    // Hide typing indicator before showing message
-    typingIndicator.style.display = 'none';
+        // Simulate thinking time
+        setTimeout(() => {
+            // Hide typing indicator before showing message
+            typingIndicator.style.display = 'none';
 
-    const response = getBotResponse(text);
-    addMessage(response, 'bot');
-}, 800);
+            const response = getBotResponse(text);
+            addMessage(response, 'bot');
+        }, 800);
 
     }
 
@@ -161,7 +192,7 @@ function parseMarkdown(text) {
 
     // Preserve line breaks
     text = text.replace(/\n/g, "<br>");
-    
+
     return text;
 }
 


### PR DESCRIPTION
Fixes: #896 


## 📋 Description

This PR introduces quick-access suggestion chips inside the chatbot to improve beginner onboarding and user guidance.

-- Added predefined clickable suggestion chips below the welcome message.
-- Suggestions include:
   -- Know about Open Source
   -- Beginner Guide
   -- Git Push Command
   -- How to Raise a PR
   -- Contribution Guide
-- Clicking a suggestion automatically sends the message.
-- Suggestions hide after selection to maintain a clean UI.
-- Designed for future dynamic population from FAQs or intents.

Why This Change?

-- The chatbot previously required users to type everything manually.
-- Beginners may not know what to ask initially.
-- Suggestion chips improve discoverability and reduce friction.
-- Enhances UX and makes onboarding faster.

------------------------------------------------------------

## 📸 Screenshots (MANDATORY for UI/UX changes)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f140b853-8868-4c76-93e6-e1c31f7fca56" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cee2801b-9f98-4304-9b17-6117dab45e9f" />


-- [x] This PR includes UI/UX changes → Screenshots attached
-- [ ] This PR does NOT include UI/UX changes

-- Screenshots show suggestion chips displayed below the welcome message.
-- Demonstrates auto-send behavior when a chip is clicked.
-- Shows clean UI after chips hide post interaction.


---

Note: I have worked on this under `SWoC26`...!
@sayeeg-11 please review...