### PR TITLE
Fix unintended glow artifacts and unify card highlight styling

### DIFF
--- a/frontend/pages/Event/outreachy.html
+++ b/frontend/pages/Event/outreachy.html
@@ -1416,6 +1416,64 @@
                 transform: translateY(-50px);
             }
         }
+
+        /* ==== Global Highlight Stabilizer ==== */
+
+        /* Kill glow pseudo-element everywhere */
+         .benefits-card.highlight::after,
+         .card.highlight::after,
+         .highlight::after {
+         display: none !important;
+        }
+
+         /* Unified card glass style */
+         .benefits-card,
+         .card {
+         background: rgba(255, 255, 255, 0.88) !important;
+         backdrop-filter: blur(8px);
+         -webkit-backdrop-filter: blur(8px);
+         box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+         border: 1px solid rgba(255, 255, 255, 0.05);
+        }
+
+        /* Dark mode consistency */
+        body.dark-mode .benefits-card,
+        body.dark-mode .card {
+         background: rgba(27, 34, 53, 0.92) !important;
+        }
+
+        /* Controlled gold accent instead of glow */
+        .highlight {
+         border: 1px solid rgba(212, 175, 55, 0.35) !important;
+          box-shadow: 0 10px 25px rgba(212, 175, 55, 0.12) !important;
+        }
+
+        /* Tone down background bloom globally */
+        .benefits-bg {
+         opacity: 0.04 !important;
+         filter: blur(80px) !important;
+        }
+
+        /* ==== Remove ALL Golden Borders from Cards ==== */
+
+        .benefits-card,
+        .card,
+        .highlight {
+         border: 1px solid rgba(255, 255, 255, 0.05) !important;
+         border-left: 1px solid rgba(255, 255, 255, 0.05) !important;
+         box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35) !important;
+        }
+
+        /* Kill any leftover pseudo-border effects */
+        .benefits-card::before,
+        .benefits-card::after,
+        .card::before,
+        .card::after,
+        .highlight::before,
+        .highlight::after {
+         border: none !important;
+        }
+        
     </style>
     <link rel='manifest' href='../../../manifest.json' />
 </head>


### PR DESCRIPTION
## 📋 Description
This PR resolves unintended golden glow and border artifacts appearing on highlighted cards across multiple sections. The issue was caused by overlapping blur filters, radial gradients, and pseudo-element glow effects stacking visually.

Changes Made
	•	Removed blurred ::after pseudo-element glow from highlighted cards
	•	Standardized card background opacity for better contrast control
	•	Replaced glow-based emphasis with subtle border styling
	•	Added a global override to ensure consistent highlight behavior
	•	Reduced background bloom intensity to prevent color bleeding

Result
	•	Consistent visual hierarchy across all card sections
	•	No unintended golden glow artifacts
	•	Cleaner, more controlled glassmorphism effect
	•	Improved UI polish and maintainability


## 📸 Screenshots 
Before
<img width="1454" height="756" alt="Screenshot 2026-02-22 at 1 27 05 PM" src="https://github.com/user-attachments/assets/4c119645-f6b0-4f4f-95b0-8e2a745f51d2" />
<img width="1463" height="757" alt="Screenshot 2026-02-22 at 1 26 52 PM" src="https://github.com/user-attachments/assets/674cca0f-c5f0-4adc-a2d9-b90e79436f38" />
<img width="1466" height="760" alt="Screenshot 2026-02-22 at 1 26 39 PM" src="https://github.com/user-attachments/assets/88821479-9d3c-44e6-bb04-579dc29b2914" />

After
<img width="1458" height="758" alt="Screenshot 2026-02-22 at 1 41 27 PM" src="https://github.com/user-attachments/assets/e62944dd-ff49-4f5b-80ad-b1379f1ffb08" />
<img width="1465" height="753" alt="Screenshot 2026-02-22 at 1 41 49 PM" src="https://github.com/user-attachments/assets/66183221-27e1-45bb-ad6c-bb9aea18a487" />
<img width="1462" height="759" alt="Screenshot 2026-02-22 at 1 42 05 PM" src="https://github.com/user-attachments/assets/787e68f9-086d-4d6e-ac98-81bb424b9fcd" />

Fixes #943 
