### PR TITLE
Removed Duplicacy in the Section on the GSSOC Page

### DIFF
--- a/frontend/pages/Event/gssoc.html
+++ b/frontend/pages/Event/gssoc.html
@@ -2711,58 +2711,42 @@
     </section>
 
     <!-- Pro Tips Section -->
-<section class="pro-tips-section">
-    <h2>Pro Tips for GSSOC Contributors</h2>
-    <p class="pro-tips-subtitle">
-        Actionable guidance to help beginners confidently start and succeed in GSSOC.
-    </p>
+    <section class="pro-tips-section">
+        <h2>Pro Tips for GSSOC Contributors</h2>
+        <p class="pro-tips-subtitle">
+            Actionable guidance to help beginners confidently start and succeed in GSSOC.
+        </p>
 
-    <div class="pro-tips-grid">
-        <div class="pro-tip-card">
-            <div class="tip-icon"><i class="fas fa-search"></i></div>
-            <h3>Choose Beginner-Friendly Issues</h3>
-            <p>Look for labels like <strong>good first issue</strong> or <strong>beginner</strong> to start with manageable tasks and build confidence.</p>
+        <div class="pro-tips-grid">
+            <div class="pro-tip-card">
+                <div class="tip-icon"><i class="fas fa-search"></i></div>
+                <h3>Choose Beginner-Friendly Issues</h3>
+                <p>Look for labels like <strong>good first issue</strong> or <strong>beginner</strong> to start with manageable tasks and build confidence.</p>
+            </div>
+
+            <div class="pro-tip-card">
+                <div class="tip-icon"><i class="fas fa-comments"></i></div>
+                <h3>Communicate with Mentors</h3>
+                <p>Ask questions early, clarify doubts, and stay active in project discussions to avoid confusion and delays.</p>
+            </div>
+
+            <div class="pro-tip-card">
+                <div class="tip-icon"><i class="fas fa-code-branch"></i></div>
+                <h3>Write Quality PR Descriptions</h3>
+                <p>Clearly explain what you changed, why you changed it, and link the issue to improve review speed.</p>
+            </div>
+
+            <div class="pro-tip-card">
+                <div class="tip-icon"><i class="fas fa-chart-line"></i></div>
+                <h3>Stay Consistent</h3>
+                <p>Regular small contributions are better than one large PR. Consistency improves rankings and learning.</p>
+            </div>
         </div>
+    </section>
 
-        <div class="pro-tip-card">
-            <div class="tip-icon"><i class="fas fa-comments"></i></div>
-            <h3>Communicate with Mentors</h3>
-            <p>Ask questions early, clarify doubts, and stay active in project discussions to avoid confusion and delays.</p>
-        </div>
-
-        <div class="pro-tip-card">
-            <div class="tip-icon"><i class="fas fa-code-branch"></i></div>
-            <h3>Write Quality PR Descriptions</h3>
-            <p>Clearly explain what you changed, why you changed it, and link the issue to improve review speed.</p>
-        </div>
-
-        <div class="pro-tip-card">
-            <div class="tip-icon"><i class="fas fa-chart-line"></i></div>
-            <h3>Stay Consistent</h3>
-            <p>Regular small contributions are better than one large PR. Consistency improves rankings and learning.</p>
-        </div>
-    </div>
-</section>
-
-
+    <div id="footer"></div>
     <script src="../../js/theme.js"></script>
-
-
-      
-
-      
-
-    </div>
-
-    <div id="footer"></div>
     <script src="../../js/DMtheme.js"></script>
-
-
-
-  </div>
-</section>
-
-    <div id="footer"></div>
     <script src="../../js/components.js"></script>
     <script>
         // Smooth scroll for anchor links


### PR DESCRIPTION
## 📋 Description
I removed the duplicated tags in the page to get rid of the repeated sections.

---

## 📸 Screenshots (MANDATORY for UI/UX changes)
<img width="1918" height="960" alt="Screenshot 2026-02-27 191804" src="https://github.com/user-attachments/assets/bd6131db-715e-42b1-9a1f-9eca917edb90" />


- [X] This PR includes UI/UX changes → Screenshots attached

Fixes #955 