### PR TITLE
Move “Have Your Own Success Story?” Banner Below Success Stories Section

### DIFF
--- a/frontend/pages/success-stories.html
+++ b/frontend/pages/success-stories.html
@@ -37,19 +37,6 @@
         </div>
     </section>
 
-    <!-- Submit Story CTA -->
-    <section class="submit-story-banner">
-        <div class="submit-banner-content">
-            <div class="submit-banner-text">
-                <h3>📝 Have Your Own Success Story?</h3>
-                <p>Share your journey and inspire others in the community!</p>
-            </div>
-            <button class="submit-story-btn" onclick="openSubmitModal()">
-                <i class="fas fa-plus"></i>
-                Share Your Story
-            </button>
-        </div>
-    </section>
 
     <!-- Stories Grid -->
     <main class="stories-main">
@@ -120,6 +107,19 @@
         </div>
     </div>
 
+    <!-- Submit Story CTA -->
+    <section class="submit-story-banner">
+        <div class="submit-banner-content">
+            <div class="submit-banner-text">
+                <h3>📝 Have Your Own Success Story?</h3>
+                <p>Share your journey and inspire others in the community!</p>
+            </div>
+            <button class="submit-story-btn" onclick="openSubmitModal()">
+                <i class="fas fa-plus"></i>
+                Share Your Story
+            </button>
+        </div>
+    </section>
     <!-- Comment Modal -->
     <div id="commentModal" class="modal">
         <div class="modal-content">


### PR DESCRIPTION
## 📋 Description
This PR improves the content flow on the Success Stories page by repositioning the “Have Your Own Success Story?” banner below the list of community success stories instead of displaying it above them.

Previously, users saw the call-to-action before exploring existing stories, which disrupted the natural reading experience. With this update, users first engage with community stories and are then encouraged to share their own journey at the end of the page.

🔧 Changes Made
Moved the share-story-banner HTML section below the success stories container
Updated layout structure in:
frontend/pages/success-stories.html
No changes to styling, CSS classes, or functionality
Preserved responsiveness and existing UI design

## 📸 Screenshots (MANDATORY for UI/UX changes)
<img width="1919" height="1013" alt="image" src="https://github.com/user-attachments/assets/e8f71ae6-319c-43f9-b905-0ef79a517c73" />


- [ ] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

Closes #990 