### PR TITLE
Add Consistent Gradient Footer to PDF Guide Page Matching Global UI

### DIFF
--- a/frontend/css/pdf_guide.css
+++ b/frontend/css/pdf_guide.css
@@ -425,3 +425,122 @@ footer a:hover {
     font-size: 1.5rem;
   }
 }
+
+/* ===== OpenSource Compass Footer (Gradient Style) ===== */
+.osc-footer {
+  background: linear-gradient(135deg, #0b1d2a, #132f4c, #0f2135);
+  color: #ffffff;
+  padding: 3rem 2rem 1.5rem;
+  margin-top: 4rem;
+  font-family: 'Inter', sans-serif;
+}
+
+.footer-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 3rem;
+  align-items: flex-start;
+}
+
+.footer-brand h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #ffffff;
+}
+
+.brand-title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.brand-icon {
+  font-size: 1.5rem;
+  background: #d4af37;
+  color: #0b1d2a;
+  padding: 6px 10px;
+  border-radius: 10px;
+  font-weight: bold;
+}
+
+.footer-brand p {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #cfd8dc;
+  margin-bottom: 1.2rem;
+}
+
+.footer-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.footer-badges span {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+}
+
+.footer-column h4 {
+  color: #d4af37;
+  font-size: 0.9rem;
+  letter-spacing: 1px;
+  margin-bottom: 1rem;
+}
+
+.footer-column a {
+  display: block;
+  text-decoration: none;
+  color: #e0e0e0;
+  margin-bottom: 0.6rem;
+  font-size: 0.9rem;
+  transition: 0.2s ease;
+}
+
+.footer-column a:hover {
+  color: #d4af37;
+  transform: translateX(3px);
+}
+
+.footer-bottom {
+  text-align: center;
+  margin-top: 2.5rem;
+  padding-top: 1.2rem;
+  border-top: 1px solid rgba(255,255,255,0.1);
+  font-size: 0.85rem;
+  color: #b0bec5;
+}
+
+.footer-bottom a {
+  color: #d4af37;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.footer-bottom a:hover {
+  text-decoration: underline;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 900px) {
+  .footer-container {
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .footer-container {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .footer-badges {
+    justify-content: center;
+  }
+}

--- a/frontend/pages/pdf_guide.html
+++ b/frontend/pages/pdf_guide.html
@@ -16,20 +16,7 @@
 
 <body>
   <!-- Navbar -->
-  <header>
-    <div class="navbar-container">
-      <h1>
-        <i class="fas fa-compass" style="color: var(--primary-gold); margin-right: 0.4rem"></i>
-        OpenSource Compass
-      </h1>
-      <div class="nav-links">
-        <a href="/OpenSource-Compass/index.html">Home</a>
-        <a href="./programs.html">Programs</a>
-        <a href="./Resources.html">Resources</a>
-        <a href="./Contribute.html">Contribute</a>
-      </div>
-    </div>
-  </header>
+ <header id="navbar"></header>
 
   <!-- Hero Section -->
   <div class="hero-section" id="home">
@@ -182,14 +169,66 @@
     </div>
   </div>
 
-  <!-- Footer -->
-  <footer>
-    <p>
-      © 2026 OpenSource Compass ·
-      <a href="https://github.com/sayeeg-11/opensource-compass">GitHub</a> ·
-      Made with <i class="fas fa-heart" style="color: var(--primary-gold);"></i> for the Open Source Community
-    </p>
-  </footer>
+   <!-- ===== OpenSource Compass Styled Footer ===== -->
+<footer class="osc-footer">
+  <div class="footer-container">
+
+    <!-- Brand Section -->
+    <div class="footer-brand">
+      <div class="brand-title">
+        <span class="brand-icon">🧭</span>
+        <h3>OpenSource Compass</h3>
+      </div>
+      <p>
+        OpenSource Compass is a beginner-friendly, community-driven platform that guides students and first-time
+        contributors in open source. It offers Git/GitHub basics, contribution best practices, and a hub for programs like
+        SWoCs, GSSoC, GSoC, Hacktoberfest, etc.
+      </p>
+
+      <div class="footer-badges">
+        <span>🛡 Community-safe</span>
+        <span>⚡ Beginner-ready</span>
+        <span>🌍 Open source</span>
+        <span>⬇ Install App</span>
+      </div>
+    </div>
+
+    <!-- Explore -->
+    <div class="footer-column">
+      <h4>EXPLORE</h4>
+      <a href="/OpenSource-Compass/index.html">Home</a>
+      <a href="./guides.html">Guides</a>
+      <a href="./programs.html">Programs</a>
+      <a href="./Resources.html">Resources</a>
+    </div>
+
+    <!-- Community -->
+    <div class="footer-column">
+      <h4>COMMUNITY</h4>
+      <a href="./contributors.html">Contributors</a>
+      <a href="./Contribute.html">Contribute</a>
+      <a href="./faq.html">FAQ</a>
+    </div>
+
+    <!-- Project -->
+    <div class="footer-column">
+      <h4>PROJECT</h4>
+      <a href="https://github.com/sayeeg-11/OpenSource-Compass" target="_blank">GitHub</a>
+      <a href="#">Contributing</a>
+      <a href="#">Code of Conduct</a>
+    </div>
+
+  </div>
+
+  <!-- Bottom Bar -->
+  <div class="footer-bottom">
+    © 2026 OpenSource Compass ·
+    <a href="https://github.com/sayeeg-11/OpenSource-Compass" target="_blank">
+      ⭐ Star on GitHub
+    </a>
+  </div>
+</footer>
+    <script src="../js/components.js"></script>
   <script src='../js/pwa.js'></script>
 </body>
 </html>


### PR DESCRIPTION
## 📋 Description
This PR replaces the minimal static footer on the PDF Guide page with a fully structured, gradient-styled footer that matches the existing OpenSource Compass design system used across other pages. The new footer includes branding, navigation columns (Explore, Community, Project), badge pills, and a bottom GitHub section to ensure visual and structural consistency across the platform.

This resolves the design inconsistency where the page previously ended abruptly with a simple text footer.

## 📸 Screenshots (MANDATORY for UI/UX changes)
<img width="1919" height="1016" alt="image" src="https://github.com/user-attachments/assets/a0cfea36-985d-4952-ab94-0bf4036ddf84" />

- [ ] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

Closes #997 