### PR TITLE
Fix: Remove floating glossary header

### DIFF
--- a/frontend/css/glossary.css
+++ b/frontend/css/glossary.css
@@ -37,11 +37,7 @@ body.dark-mode .glossary-hero h1 {
   color: var(--text-secondary);
   line-height: 1.7;
 }
-.glossary-search-wrapper {
-  max-width: 720px;
-  margin: -36px auto 64px;
-  padding: 0 16px;
-}
+
 
 .glossary-search-wrapper input {
   width: 100%;
@@ -163,6 +159,40 @@ body.dark-mode .explorer-card h3 {
   margin-bottom: 20px;
 }
 
+/* ===== FIX: Align "All Glossary Terms" inside layout container ===== */
+/* ===== Minimal Inline Section Header (NO FLOAT, NO BACKGROUND) ===== */
+.library-header {
+  max-width: 1200px;
+  margin: 0 auto 32px auto;
+  padding: 0 1.5rem;
+  background: none;        /* removes orange background */
+  box-shadow: none;        /* removes floating card feel */
+  border-radius: 0;
+  position: static;        /* ensures it stays in normal flow */
+  text-align: center;
+}
+
+.library-header p {
+  color: #6b7280;
+  font-size: 1rem;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Proper spacing after hero */
+.glossary-hero {
+  margin-bottom: 2rem;
+}
+
+.glossary-library {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 40px 1.5rem 3rem 1.5rem; /* adds natural spacing from explorer */
+  box-sizing: border-box;
+}
+
 .explorer-card .count {
   font-size: 0.75rem;
   letter-spacing: 1px;
@@ -170,20 +200,19 @@ body.dark-mode .explorer-card h3 {
   color: var(--secondary-gold);
   font-weight: 600;
 }
-.glossary-library {
-  padding: 104px 16px 120px;
-  background:
-    linear-gradient(
-      180deg,
-      rgba(212,175,55,0.04),
-      transparent 35%
-    );
+
+
+/* Fix spacing between hero and glossary section */
+.glossary-hero {
+  margin-bottom: 2rem;
 }
 
-.library-header {
-  max-width: 760px;
-  margin: 0 auto 72px;
-  text-align: center;
+.glossary-search-wrapper {
+  max-width: 720px;
+  margin: 24px auto 48px auto; /* remove negative margin */
+  padding: 0 16px;
+  display: flex;
+  justify-content: center;
 }
 
 .library-header h2 {
@@ -366,12 +395,7 @@ body.dark-mode .glossary-empty h3 {
     0 0 0 6px rgba(212,175,55,0.12),
     var(--shadow-hover);
 }
-.library-header {
-  max-width: 760px;
-  margin: 0 auto 80px;
-  text-align: center;
-  position: relative;
-}
+
 
 /* Eyebrow label */
 .section-eyebrow {
@@ -397,22 +421,6 @@ body.dark-mode .library-header h2 {
   color: var(--text-primary);
 }
 
-/* Subtle gold underline accent */
-.library-header h2::after {
-  content: "";
-  display: block;
-  width: 64px;
-  height: 3px;
-  margin: 20px auto 0;
-  border-radius: 999px;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    var(--primary-gold),
-    transparent
-  );
-  opacity: 0.85;
-}
 
 /* Description */
 .library-header p {

--- a/frontend/pages/glossary.html
+++ b/frontend/pages/glossary.html
@@ -28,7 +28,7 @@
     <header>
         <div class="navbar-container">
             <h1>
-                <i class="fas fa-compass" style="color: var(--primary-gold); margin-right: 0.4rem"></i>
+                <i class="fas fa-compass" style="color: #f9f9f9; margin-right: 0.4rem"></i>
                 OpenSource Compass
             </h1>
             <div class="nav-links">
@@ -101,13 +101,6 @@
             </div>
         </section>
         <section class="glossary-library" id="glossary">
-            <header class="library-header">
-                <h2>All Glossary Terms</h2>
-                <p>
-                    Browse the complete collection of open-source terminology.
-                    Clear explanations, practical context, zero confusion.
-                </p>
-            </header>
 
             <div class="glossary-grid" id="glossaryGrid">
                 <!-- Glossary cards rendered here -->


### PR DESCRIPTION
## 📋 Description
This PR fixes the visual inconsistency on the Glossary page by removing the floating/unstructured header block and replacing the orange navbar background with a clean white layout for better visual hierarchy and consistency with the rest of the site.

Before:
Glossary header looked like a floating block
Visual overlap between hero and glossary header
Inconsistent spacing and hierarchy

After:
Glossary header integrated into normal page flow
No floating or overlapping elements
Consistent spacing and structured layout

## 📸 Screenshots (MANDATORY for UI/UX changes)
<img width="1919" height="1017" alt="image" src="https://github.com/user-attachments/assets/d21d6deb-b0ff-4bfc-bd4a-f3d5ea7b8ebe" />

- [ ] This PR includes UI/UX changes → Screenshots attached
- [ ] This PR does NOT include UI/UX changes

Closes #999 