### PR TITLE
fix: remove duplicate FAQ questions, clean up CSS and scripts, reorder CTA card

### DIFF
--- a/frontend/pages/faq.html
+++ b/frontend/pages/faq.html
@@ -323,134 +323,7 @@ body.dark-mode .faq-answer p {
   <main>
     <section>
       <h3>Frequently Asked Questions</h3>
-      <p>Common questions about OpenSource Compass and open source contributions.</p>
-
-      <div class="faq-accordion">
-  <div class="faq-item">
-    <button class="faq-question">
-      What is OpenSource Compass?
-      <i class="fas fa-chevron-down"></i>
-    </button>
-    <div class="faq-answer">
-      <p>OpenSource Compass is a platform that helps beginners navigate open source by providing structured guides, resources, and program information.</p>
-    </div>
-  </div>
-
-  <div class="faq-item">
-    <button class="faq-question">
-      Do I need programming experience?
-      <i class="fas fa-chevron-down"></i>
-    </button>
-    <div class="faq-answer">
-      <p>No. You can contribute to open source through documentation, design, testing, community support, and many other non-coding roles.</p>
-    </div>
-  </div>
-
-  <div class="faq-item">
-    <button class="faq-question">
-      How do I get started with open source?
-      <i class="fas fa-chevron-down"></i>
-    </button>
-    <div class="faq-answer">
-      <p>Start by reading contribution guides, choosing a beginner-friendly project, and working on small issues such as documentation or bug fixes.</p>
-    </div>
-  </div>
-
-  <div class="faq-item">
-    <button class="faq-question">
-      How do I choose a project to contribute to?
-      <i class="fas fa-chevron-down"></i>
-    </button>
-    <div class="faq-answer">
-      <p>Pick projects that match your interests and skill level. Look for repositories with labels like “good first issue” or “help wanted”.</p>
-    </div>
-  </div>
-
-  <div class="faq-item">
-    <button class="faq-question">
-      What are the benefits of contributing to open source?
-      <i class="fas fa-chevron-down"></i>
-    </button>
-    <div class="faq-answer">
-      <p>Contributing helps you build a portfolio, improve technical skills, collaborate globally, and gain real-world development experience.</p>
-    </div>
-  </div>
-
-  <div class="faq-item">
-    <button class="faq-question">
-      Where can I ask for help?
-      <i class="fas fa-chevron-down"></i>
-    </button>
-    <div class="faq-answer">
-      <p>Most projects have active communities on GitHub, Discord, or Slack. Asking questions is encouraged and is part of open-source culture.</p>
-    </div>
-  </div>
-
-  <div class="faq-item">
-    <button class="faq-question">
-      How do I find beginner-friendly issues?
-      <i class="fas fa-chevron-down"></i>
-    </button>
-    <div class="faq-answer">
-      <p>Look for repositories with labels like <strong>good first issue</strong>, <strong>beginner</strong>, or <strong>help wanted</strong>.</p>
-    </div>
-  </div>
-
-  <div class="faq-item">
-    <button class="faq-question">
-      What is a “good first issue”?
-      <i class="fas fa-chevron-down"></i>
-    </button>
-    <div class="faq-answer">
-      <p>A good first issue is a small, well-defined task that helps beginners understand the project without deep knowledge of the entire codebase.</p>
-    </div>
-  </div>
-
-  <div class="faq-item">
-    <button class="faq-question">
-      Do I need to know Git before contributing?
-      <i class="fas fa-chevron-down"></i>
-    </button>
-    <div class="faq-answer">
-      <p>Basic Git knowledge is helpful, but not mandatory. Many projects provide step-by-step contribution guides.</p>
-    </div>
-  </div>
-
-  <div class="faq-item">
-    <button class="faq-question">
-      How should I communicate with maintainers?
-      <i class="fas fa-chevron-down"></i>
-    </button>
-    <div class="faq-answer">
-      <p>Be polite, clear, and patient. Use GitHub issues or discussions to ask questions and seek feedback before starting work.</p>
-    </div>
-  </div>
-
-  <div class="faq-item">
-    <button class="faq-question">
-      What should I do if my pull request is rejected?
-      <i class="fas fa-chevron-down"></i>
-    </button>
-    <div class="faq-answer">
-      <p>Don’t be discouraged. Read the feedback carefully, make the suggested changes, or ask for clarification.</p>
-    </div>
-  </div>
-</div>
-
-<!-- Didn't Find Your Answer Card -->
-<div class="faq-cta-card">
-  <div class="faq-cta-content">
-    <h4>Didn’t find your answer?</h4>
-    <p>
-      Ask your question or share your feedback and we’ll help you out.
-      Your query might also help improve this platform for others.
-    </p>
-    <a href="../pages/feedback.html" class="faq-cta-btn">
-      <i class="fas fa-paper-plane"></i>
-      Ask Your Question
-    </a>
-  </div>
-</div>
+      <p>Common questions about OpenSource Compass and open source contributions.</p> 
 
       <div class="faq-container">
 
@@ -620,6 +493,22 @@ body.dark-mode .faq-answer p {
         </div>
 
       </div>
+
+      <!-- Didn't Find Your Answer Card -->
+      <div class="faq-cta-card">
+        <div class="faq-cta-content">
+          <h4>Didn’t find your answer?</h4>
+            <p>
+            Ask your question or share your feedback and we’ll help you out.
+            Your query might also help improve this platform for others.
+            </p>
+          <a href="../pages/feedback.html" class="faq-cta-btn">
+            <i class="fas fa-paper-plane"></i>
+              Ask Your Question
+          </a>
+       </div>
+      </div>
+
 
     </section>
   </main>


### PR DESCRIPTION
## 📋 Description
Fixes duplicate FAQ questions on the FAQ page, cleans up redundant CSS 
and JavaScript, and moves the CTA card to the correct position at the bottom.


## 📸 Screenshots 
Before
<img width="1468" height="756" alt="Screenshot 2026-03-01 at 9 10 36 AM" src="https://github.com/user-attachments/assets/9bd14017-4b0a-45db-b9bb-6c7032ee268a" />
<img width="1470" height="677" alt="Screenshot 2026-03-01 at 9 12 48 AM" src="https://github.com/user-attachments/assets/fb560cdf-689b-4497-8264-3b99c7106118" />
<img width="1470" height="674" alt="Screenshot 2026-03-01 at 9 13 04 AM" src="https://github.com/user-attachments/assets/cd2ba77b-1fad-4a2c-b449-e039d992f64e" />
<img width="1463" height="674" alt="Screenshot 2026-03-01 at 9 13 20 AM" src="https://github.com/user-attachments/assets/03a0750d-4830-4a76-b120-5f022c9498aa" />


After

<img width="1467" height="762" alt="Screenshot 2026-03-01 at 9 26 35 AM" src="https://github.com/user-attachments/assets/5a8ff61e-e534-4657-92a7-70f02885cdfb" />
<img width="1470" height="665" alt="Screenshot 2026-03-01 at 9 26 49 AM" src="https://github.com/user-attachments/assets/0a43ad2d-41dd-40f6-8597-6d39e1d75eb0" />
<img width="1467" height="611" alt="Screenshot 2026-03-01 at 9 27 02 AM" src="https://github.com/user-attachments/assets/543f69da-3ed2-44f0-b9fc-27bad0fa942e" />

Fixes #1092 